### PR TITLE
feat: Add Umwelt/Emissionen

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,6 @@ Bitte bei der Nutzung der Links unbedingt darauf achten, unter welcher Lizenz di
 - Fahrstühle und Rolltreppen: https://developer.deutschebahn.com/store/apis/info?name=FaSta-Station_Facilities_Status&version=v2&provider=DBOpenData
 - Flinkster Carsharing: https://developer.deutschebahn.com/store/apis/info?name=Flinkster_API_NG&version=v1&provider=DBOpenData
 - Verspätungsdaten DB Cargo: https://developer.deutschebahn.com/store/apis/info?name=Cargo-Delay-Statistics&version=v1&provider=DBOpenData
+- Umwelt/Emissionen:
+  - https://triptocarbon.xyz/
+  - http://www.ecopassenger.org/bin/query.exe/en?L=vs_uic (aktuell keine API)


### PR DESCRIPTION
Follow up from https://github.com/dbsystel/Bahn-API/issues/4

I hope you'll find this a useful addition to the already comprehensive list: 

- triptocarbon.xyz is not dedicated to rail service but instead allows to compare different modes of transport using emission factors (the numbers are not specifically for DB!)
- ecopassenger.com is the backend for UmweltCheck but unfortunately there isn't programmatic access at the time of writing. They are however considering adding/allowing that. 

Thank you for maintaining the repo!